### PR TITLE
Tested wordpress plugin with version 4.7.1

### DIFF
--- a/trunk/readme.txt
+++ b/trunk/readme.txt
@@ -3,8 +3,8 @@
 Contributors: fracturedatlas, jakilevy, markoof, rzvagelsky
 Tags: artful.ly api, widget, ticket, ticket sales, Artful.ly, Artfully, ticketing, donations, donation, arts
 Requires at least: 3.3.1
-Tested up to: 4.1
-Stable tag: 1.0.1
+Tested up to: 4.7.1
+Stable tag: 1.0.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
https://trello.com/c/PGHt0IE3/317-test-artful-ly-widget-s-compatibility-with-wordpress-4-7?menu=filter&filter=label:Artful.ly

Hello, fracturedatlas!

WordPress 4.7 has just been released! Are your plugins ready?

After testing your plugins and ensuring compatibility, it only takes a few moments to change the readme "Tested up to:" value to 4.7. This information provides peace of mind to users and helps encourage them to update to the latest version.

Here are the current "Tested up to:" values for each of your plugins:

https://wordpress.org/plugins/artfully-widget/ (tested up to 4.3.1)
For each plugin that is compatible, you don't need to release a new version -- just change the stable version's readme value.

Looking to get more familiar with 4.7? Read this roundup post on the core development blog to check out the changes made to REST API content endpoints, post type templates, admin language and locale switching, WP_Taxonomy, multisite, and much, much more: https://make.wordpress.org/core/2016/12/05/wordpress-4-7-field-guide/

Thank you for all you do for the WordPress community, and we hope you enjoy 4.7 as much as we do.

WordPress core contributors

P.S. If you haven't heard, a major update to the WordPress Plugin Directory is nearly complete. You can preview the new version at https://wordpress.org/plugins-wp/ while it's in public beta. After doing so, your feedback would be greatly appreciated at https://mapk.polldaddy.com/s/new-plugin-directory